### PR TITLE
Reduce required Moodle version to 2.7

### DIFF
--- a/version.php
+++ b/version.php
@@ -21,7 +21,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2015070300;               // If version == 0 then module will not be installed
-$plugin->requires  = 2014111000;      // Requires this Moodle version
+$plugin->requires  = 2014051200;      // Requires this Moodle version
 $plugin->maturity  = MATURITY_ALPHA;
 $plugin->cron      = 0;               // Period for cron to check this module (secs)
 $plugin->component = 'local_nagios'; // To check on upgrade, that module sits in correct place


### PR DESCRIPTION
I've performed basic testing on Moodle 2.7, as well as scanning the changes in e881bfdddf876959bb8fd72973eacec4904a5938 - and can't see any 2.7 compatibility issues.
