### PR TITLE
Add support for "option" params for task-specific parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ define command{
         }
 ```
 Note the use of Moodle-style parameter passing (using =). Use these command in Nagios service definitions as normal.
+Pass additional (service-specific) params using one or more -o (--option) parameters, i.e. -o=task='\\core\\task\\events_cron_task'
 
 ## Permission requirements
 

--- a/script/check_moodle
+++ b/script/check_moodle
@@ -34,8 +34,10 @@ my $php_options = {
     'critical' => undef
 };
 
+my $service_options;
+
 GetOptions('plugin=s' => \$plugin, 'service=s' => \$service, 'warning=s' => \$php_options->{'warning'}, 
-    'critical=s' => \$php_options->{'critical'}, 'verbose+' => \$verbose);
+    'critical=s' => \$php_options->{'critical'}, 'verbose+' => \$verbose, 'option=s%' => \$service_options);
 
 die "plugin required" if not defined $plugin;
 die "service required" if not defined $service;
@@ -47,6 +49,13 @@ for my $key ( keys %$php_options) {
         $command .=  " --$key=$value";
     }
 };
+
+for my $key ( keys %$service_options) {
+	my $value = $service_options->{$key};
+	if (defined $value) {
+		$command .=  " --$key=$value";
+	}
+}
 
 my $result = qx/$command/;
 print $result;


### PR DESCRIPTION
Call the check_moodle script with one or more -o (--option) params with
name/value pairs (i.e. task='\core\task\events_cron_task') to pass
service-specific parameters as appropriate.

This resolves #1 - though as per that ticket, I'm open to suggested improvements.
